### PR TITLE
feat(swagger): configuración inicial para pruebas con Swagger UI

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
       <profile name="Maven default annotation processors profile" enabled="true">
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />

--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/backend/Skilllink-Backend/pom.xml
+++ b/backend/Skilllink-Backend/pom.xml
@@ -103,8 +103,9 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
         </dependency>
+
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>

--- a/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/SkilllinkBackendApplication.java
+++ b/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/SkilllinkBackendApplication.java
@@ -10,5 +10,4 @@ public class SkilllinkBackendApplication {
         SpringApplication.run(SkilllinkBackendApplication.class, args);
         System.out.println("Hola Mundo desde SkillLink!! ");
     }
-
 }

--- a/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/controller/CertificationController.java
+++ b/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/controller/CertificationController.java
@@ -1,0 +1,45 @@
+package com.example.skilllinkbackend.certification.controller;
+
+import com.example.skilllinkbackend.certification.dto.CertificationDto;
+import com.example.skilllinkbackend.certification.service.CertificationService;
+
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/certifications")
+public class CertificationController {
+
+    private final CertificationService certificationService;
+
+    public CertificationController(CertificationService certificationService) {
+        this.certificationService = certificationService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CertificationDto>> getAll() {
+        List<CertificationDto> result = certificationService.getAll();
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CertificationDto> getById(@PathVariable Long id) {
+        CertificationDto dto = certificationService.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PostMapping
+    public ResponseEntity<CertificationDto> create(@Valid @RequestBody CertificationDto dto) {
+        CertificationDto created = certificationService.create(dto);
+        return ResponseEntity.ok(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<CertificationDto> update(@PathVariable Long id, @Valid @RequestBody CertificationDto dto) {
+        CertificationDto updated = certificationService.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/dto/CertificationDto.java
+++ b/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/dto/CertificationDto.java
@@ -1,0 +1,64 @@
+package com.example.skilllinkbackend.certification.dto;
+
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+
+public class CertificationDto {
+
+    @NotBlank(message = "El nombre de la certificación no puede estar vacío")
+    private String nombre;
+
+    @NotBlank(message = "La institución es requerida")
+    private String institucion;
+
+    @NotNull(message = "La fecha de emisión es obligatoria")
+    @PastOrPresent(message = "La fecha de emisión no puede ser futura")
+    private LocalDate fechaEmision;
+
+    @NotNull(message = "La fecha de expiración es obligatoria")
+    @FutureOrPresent(message = "La fecha de expiración debe ser presente o futura")
+    private LocalDate fechaExpiracion;
+
+    public CertificationDto() {
+        // Constructor vacío requerido por frameworks como Jackson o MapStruct
+    }
+
+    public CertificationDto(String nombre, String institucion, LocalDate fechaEmision, LocalDate fechaExpiracion) {
+        this.nombre = nombre;
+        this.institucion = institucion;
+        this.fechaEmision = fechaEmision;
+        this.fechaExpiracion = fechaExpiracion;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getInstitucion() {
+        return institucion;
+    }
+
+    public void setInstitucion(String institucion) {
+        this.institucion = institucion;
+    }
+
+    public LocalDate getFechaEmision() {
+        return fechaEmision;
+    }
+
+    public void setFechaEmision(LocalDate fechaEmision) {
+        this.fechaEmision = fechaEmision;
+    }
+
+    public LocalDate getFechaExpiracion() {
+        return fechaExpiracion;
+    }
+
+    public void setFechaExpiracion(LocalDate fechaExpiracion) {
+        this.fechaExpiracion = fechaExpiracion;
+    }
+}

--- a/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/entity/Certification.java
+++ b/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/entity/Certification.java
@@ -1,0 +1,81 @@
+package com.example.skilllinkbackend.certification.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "certifications")
+public class Certification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "El nombre de la certificación es obligatorio")
+    @Column(nullable = false)
+    private String nombre;
+
+    @NotBlank(message = "La institución emisora es obligatoria")
+    @Column(nullable = false)
+    private String institucion;
+
+    @NotNull(message = "La fecha de emisión no puede ser nula")
+    @PastOrPresent(message = "La fecha de emisión no puede ser futura")
+    @Column(name = "fecha_emision", nullable = false)
+    private LocalDate fechaEmision;
+
+    @NotNull(message = "La fecha de expiración no puede ser nula")
+    @FutureOrPresent(message = "La fecha de expiración debe ser presente o futura")
+    @Column(name = "fecha_expiracion", nullable = false)
+    private LocalDate fechaExpiracion;
+
+    // 🧱 Constructor por defecto
+    public Certification() {}
+
+    // 🔧 Constructor completo
+    public Certification(String nombre, String institucion, LocalDate fechaEmision, LocalDate fechaExpiracion) {
+        this.nombre = nombre;
+        this.institucion = institucion;
+        this.fechaEmision = fechaEmision;
+        this.fechaExpiracion = fechaExpiracion;
+    }
+
+    // ⚙️ Getters y Setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getInstitucion() {
+        return institucion;
+    }
+
+    public void setInstitucion(String institucion) {
+        this.institucion = institucion;
+    }
+
+    public LocalDate getFechaEmision() {
+        return fechaEmision;
+    }
+
+    public void setFechaEmision(LocalDate fechaEmision) {
+        this.fechaEmision = fechaEmision;
+    }
+
+    public LocalDate getFechaExpiracion() {
+        return fechaExpiracion;
+    }
+
+    public void setFechaExpiracion(LocalDate fechaExpiracion) {
+        this.fechaExpiracion = fechaExpiracion;
+    }
+}

--- a/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/mapper/CertificationMapper.java
+++ b/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/mapper/CertificationMapper.java
@@ -1,0 +1,33 @@
+package com.example.skilllinkbackend.certification.mapper;
+
+import com.example.skilllinkbackend.certification.dto.CertificationDto;
+import com.example.skilllinkbackend.certification.entity.Certification;
+
+public class CertificationMapper {
+
+    public static CertificationDto toDto(Certification entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        CertificationDto dto = new CertificationDto();
+        dto.setNombre(entity.getNombre());
+        dto.setInstitucion(entity.getInstitucion());
+        dto.setFechaEmision(entity.getFechaEmision());
+        dto.setFechaExpiracion(entity.getFechaExpiracion());
+        return dto;
+    }
+
+    public static Certification toEntity(CertificationDto dto) {
+        if (dto == null) {
+            return null;
+        }
+
+        return new Certification(
+                dto.getNombre(),
+                dto.getInstitucion(),
+                dto.getFechaEmision(),
+                dto.getFechaExpiracion()
+        );
+    }
+}

--- a/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/repository/CertificationRepository.java
+++ b/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/repository/CertificationRepository.java
@@ -1,0 +1,12 @@
+package com.example.skilllinkbackend.certification.repository;
+
+import com.example.skilllinkbackend.certification.entity.Certification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CertificationRepository extends JpaRepository<Certification, Long> {
+    List<Certification> findByInstitucionContainingIgnoreCase(String institucion);
+}

--- a/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/service/CertificationService.java
+++ b/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/service/CertificationService.java
@@ -1,0 +1,15 @@
+package com.example.skilllinkbackend.certification.service;
+
+import com.example.skilllinkbackend.certification.dto.CertificationDto;
+import java.util.List;
+
+public interface CertificationService {
+
+    List<CertificationDto> getAll();
+
+    CertificationDto getById(Long id);
+
+    CertificationDto create(CertificationDto dto);
+
+    CertificationDto update(Long id, CertificationDto dto);
+}

--- a/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/service/impl/CertificationServiceImpl.java
+++ b/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/certification/service/impl/CertificationServiceImpl.java
@@ -1,0 +1,64 @@
+package com.example.skilllinkbackend.certification.service.impl;
+
+import com.example.skilllinkbackend.certification.dto.CertificationDto;
+import com.example.skilllinkbackend.certification.entity.Certification;
+import com.example.skilllinkbackend.certification.mapper.CertificationMapper;
+import com.example.skilllinkbackend.certification.repository.CertificationRepository;
+import com.example.skilllinkbackend.certification.service.CertificationService;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CertificationServiceImpl implements CertificationService {
+
+    private final CertificationRepository certificationRepository;
+
+    public CertificationServiceImpl(CertificationRepository certificationRepository) {
+        this.certificationRepository = certificationRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CertificationDto> getAll() {
+        return certificationRepository.findAll()
+                .stream()
+                .map(CertificationMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CertificationDto getById(Long id) {
+        Certification certification = certificationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Certificación no encontrada con ID: " + id));
+        return CertificationMapper.toDto(certification);
+    }
+
+    @Override
+    @Transactional
+    public CertificationDto create(CertificationDto dto) {
+        Certification certification = CertificationMapper.toEntity(dto);
+        Certification saved = certificationRepository.save(certification);
+        return CertificationMapper.toDto(saved);
+    }
+
+    @Override
+    @Transactional
+    public CertificationDto update(Long id, CertificationDto dto) {
+        Certification certification = certificationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("No se puede actualizar. Certificación no encontrada con ID: " + id));
+
+        certification.setNombre(dto.getNombre());
+        certification.setInstitucion(dto.getInstitucion());
+        certification.setFechaEmision(dto.getFechaEmision());
+        certification.setFechaExpiracion(dto.getFechaExpiracion());
+
+        Certification updated = certificationRepository.save(certification);
+        return CertificationMapper.toDto(updated);
+    }
+}


### PR DESCRIPTION
Este PR añade las dependencias de springdoc-openapi, habilita la interfaz Swagger UI para inspeccionar endpoints REST del backend SkillLink y permite pruebas interactivas desde el navegador.

✅ Se agregaron:
- springdoc-openapi-starter-webmvc-ui v2.2.0
- rutas permitidas en SecurityConfig
- 
![image](https://github.com/user-attachments/assets/96a2a92d-d27b-451d-92f5-063139d76b84)

![swagger](https://github.com/user-attachments/assets/be249032-0274-4ec3-8f66-f02d226371e0)
