### PR TITLE
fix(api): create course

### DIFF
--- a/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/course/controller/CourseController.java
+++ b/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/course/controller/CourseController.java
@@ -69,7 +69,7 @@ public class CourseController {
                 ? certificationRepository.findById(dto.getCertificacionId()).orElse(null)
                 : null;
 
-        Course creado = courseService.crear(CourseMapper.toEntity(dto, instructor, cert));
+        Course creado = courseService.crear(CourseMapper.toEntityForCreate(dto, instructor, cert));
         return ResponseEntity.ok(CourseMapper.toDto(creado));
     }
 

--- a/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/course/mapper/CourseMapper.java
+++ b/backend/Skilllink-Backend/src/main/java/com/example/skilllinkbackend/course/mapper/CourseMapper.java
@@ -40,6 +40,17 @@ public class CourseMapper {
                 .build();
     }
 
+    public static Course toEntityForCreate(CourseDto dto, User instructor, Certification certificacion) {
+        return Course.builder()
+                .titulo(dto.getTitulo())
+                .descripcion(dto.getDescripcion())
+                .duracionHoras(dto.getDuracionHoras())
+                .nivel(dto.getNivel())
+                .instructor(instructor)
+                .certificacion(certificacion)
+                .build();  // No setea el id
+    }
+
     // 📤 Convierte Course a CourseResponseDto enriquecido con nombre de instructor y certificación
     public static CourseResponseDto toResponseDto(Course course) {
         if (course == null) return null;


### PR DESCRIPTION
## 🐛 Fix: Error al crear un curso

### 🔧 Cambios realizados
Esta PR soluciona el error `StaleObjectStateException` que ocurría al intentar crear un nuevo curso. El problema se debía a que el `id` se incluía incorrectamente durante el mapeo del DTO a la entidad, lo cual causaba que Hibernate intentara hacer un `merge` en lugar de un `persist`.

Los siguientes archivos fueron modificados:
- `CourseController.java`: se ajustó el controlador para utilizar el mapper adecuado para creación.
- `CourseMapper.java`: se creó un método `toEntityForCreate(...)` que excluye el `id` al construir la entidad `Course`.

### ✅ Resultado
- Se puede crear un curso exitosamente sin conflictos de estado con Hibernate.
- El flujo de persistencia es correcto y el `id` es generado automáticamente por la base de datos.

### 📌 Notas adicionales
- Se recomienda utilizar un DTO específico para la creación (`CourseCreateDto`) para evitar errores similares en el futuro.

---

✔️ Listo para revisión y merge.
