### PR TITLE
chore: delete application properties

### DIFF
--- a/backend/Skilllink-Backend/src/main/resources/application.properties
+++ b/backend/Skilllink-Backend/src/main/resources/application.properties
@@ -1,6 +1,0 @@
-spring.application.name=Skilllink-Backend
-spring.datasource.url=jdbc:postgresql://localhost:5432/skilllinkdb
-spring.datasource.username=postgres
-spring.datasource.password=Alejo123
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true


### PR DESCRIPTION
## 🔥 Eliminación de `application.properties` en favor de `application.yml`

### 📋 Descripción

Se elimina el archivo `application.properties` ubicado en:

backend/Skilllink-Backend/src/main/resources/application.properties


A partir de este cambio, toda la configuración de la aplicación se centralizará únicamente en el archivo `application.yml`, siguiendo las buenas prácticas de configuración en proyectos Spring Boot modernos.

### ✅ Motivo

- Homogeneizar el formato de configuración.
- Aprovechar las capacidades jerárquicas y más legibles de `YAML`.
- Reducir la redundancia o posibles conflictos entre archivos de configuración.

### ⚠️ Consideraciones

Asegurarse de que todas las propiedades previamente definidas en `application.properties` hayan sido correctamente migradas a `application.yml`.

### 🧪 Pruebas

- Verificado arranque correcto de la aplicación usando exclusivamente `application.yml`.
- Revisión de valores cargados en entornos `dev` y `prod` según corresponda.

---

> Este cambio simplifica la gestión de configuraciones y alinea el proyecto con las prácticas actuales de Spring Boot.
